### PR TITLE
Don't complain about missing elements in DocBlocks when {@inheritDoc} is used

### DIFF
--- a/src/StellarWP/ruleset.xml
+++ b/src/StellarWP/ruleset.xml
@@ -65,6 +65,17 @@
     <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
 
     <!--
+        Don't complain about missing elements in DocBlocks when {@inheritDoc} is used.
+
+        Reference: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties#squizcommentingfunctioncomment
+    -->
+    <rule ref="Squiz.Commenting.FunctionComment">
+        <properties>
+            <property name="skipIfInheritdoc" value="true" />
+        </properties>
+    </rule>
+
+    <!--
         Special rules for tests:
         1. Test classes may use snake_case for method names (PSR1.Methods.CamelCapsMethodName.NotCamelCaps)
         2. Test classes can use whatever methods they'd like (WordPress.PHP.DiscouragedPHPFunctions, WordPress.PHP.DevelopmentFunctions)

--- a/src/StellarWP/ruleset.xml
+++ b/src/StellarWP/ruleset.xml
@@ -67,7 +67,16 @@
     <!--
         Don't complain about missing elements in DocBlocks when {@inheritDoc} is used.
 
+        The inline `{@inheritDoc}` is only meant to be used for extending method descriptions, but the
+        "inherit everything, including arguments + return values" alternative, `@inheritDoc` (no curly-
+        braces) was never made official. As a result, many IDEs have chosen to interpret the inline
+        version as full-inheritance.
+
+        In order to prevent PHP_CodeSniffer from assuming we forgot to write documentation that *should*
+        be implicitly inherited, we're allowing `{@inheritDoc}`, even if it's not _technically_ correct.
+
         Reference: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties#squizcommentingfunctioncomment
+        Discussion: https://github.com/stellarwp/coding-standards/pull/3#discussion_r819890070
     -->
     <rule ref="Squiz.Commenting.FunctionComment">
         <properties>


### PR DESCRIPTION
Reference: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties#squizcommentingfunctioncomment