### PR TITLE
Explicitly set ordered_imports.imports_order for PHP-CS-Fixer

### DIFF
--- a/src/php-cs-fixer.php
+++ b/src/php-cs-fixer.php
@@ -59,6 +59,7 @@ return (new PhpCsFixer\Config())
         'not_operator_with_successor_space' => true,
         'ordered_imports' => [
             'sort_algorithm' => 'alpha',
+            'imports_order' => ['class', 'function', 'const'],
         ],
         'psr_autoloading' => true,
         'single_quote' => [


### PR DESCRIPTION
This PR ensures that imports are ordered thusly:

1. Classes
2. Functions
3. Constants

Example:

```php
use StellarWP\SomeClass;
use StellarWP\SomeOtherClass;

use function StellarWP\some_function;

use const StellarWP\SOME_CONSTANT;
```

Reference: https://cs.symfony.com/doc/rules/import/ordered_imports.html