### PR TITLE
Exclude /node_modules from PHP-CS-Fixer's default finder

### DIFF
--- a/src/php-cs-fixer.php
+++ b/src/php-cs-fixer.php
@@ -7,6 +7,7 @@
  */
 
 $finder = PhpCsFixer\Finder::create()
+    ->exclude('node_modules')
     ->in(getcwd());
 
 return (new PhpCsFixer\Config())


### PR DESCRIPTION
There's not really a good reason for us to be checking the coding standards of `node_modules/`, especially since it's unlikely to include many PHP files.