### PR TITLE
Disable the method_argument_space check in PHP-CS-Fixer

### DIFF
--- a/src/php-cs-fixer.php
+++ b/src/php-cs-fixer.php
@@ -38,6 +38,8 @@ return (new PhpCsFixer\Config())
         'linebreak_after_opening_tag' => true,
         'lowercase_cast' => true,
         'mb_str_functions' => true,
+        // This rule can cause issues with mixed PHP and HTML in templates.
+        'method_argument_space' => false,
         'multiline_comment_opening_closing' => true,
         'native_function_casing' => true,
         'no_blank_lines_after_class_opening' => true,


### PR DESCRIPTION
[The method_argument_space rule PHP-CS-Fixer rule](https://cs.symfony.com/doc/rules/function_notation/method_argument_space.html) can cause issues when writing templates that consist of mixed HTML and PHP:

```diff
             <a href="#">
                 <?php
                 esc_html_e(
-                    'Some text',
-                    'stellarwp'
-                );
+            'Some text',
+            'stellarwp'
+        );
                 ?>
             </a>
         </li>
```

Since this conflicts with whitespace rules provided by PHP_CodeSniffer, disable this rule by default for the coding standards.