### PR TITLE
Bump WP Coding Standards Dependency from ^2.3 → ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "stellarwp/coding-standards",
     "description": "Centralized coding standards for StellarWP packages",
-    "type" : "phpcodesniffer-standard",
+    "type": "phpcodesniffer-standard",
     "license": "MIT",
     "authors": [
         {
@@ -19,7 +19,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "friendsofphp/php-cs-fixer": "^3.5",
         "phpcompatibility/phpcompatibility-wp": "^2.1",
-        "wp-coding-standards/wpcs": "^2.3"
+        "wp-coding-standards/wpcs": "^3.0"
     },
     "require-dev": {
         "assertwell/shellcheck": "^1.0"

--- a/src/StellarWP/ruleset.xml
+++ b/src/StellarWP/ruleset.xml
@@ -18,12 +18,12 @@
     <!-- Import select WordPress rules. -->
     <rule ref="WordPress.PHP">
         <!-- Short-ternaries are fine. -->
-        <exclude name="WordPress.PHP.DisallowShortTernary" />
+        <exclude name="Universal.Operators.DisallowShortTernary" />
     </rule>
     <rule ref="WordPress.Security"/>
     <rule ref="WordPress.WP">
         <!-- This rule has been deprecated, but will pop up sometimes. -->
-        <exclude name="WordPress.WP.TimezoneChange" />
+        <exclude name="WordPress.DateTime.RestrictedFunctions" />
     </rule>
 
     <!-- WordPress Documentation standards -->

--- a/src/php-cs-fixer.php
+++ b/src/php-cs-fixer.php
@@ -20,7 +20,7 @@ return (new PhpCsFixer\Config())
             'space_before_parenthesis' => true,
         ],
         'comment_to_phpdoc' => false,
-        'compact_nullable_typehint' => true,
+        'compact_nullable_type_declaration' => true,
         'concat_space' => [
             'spacing' => 'one',
         ],
@@ -29,7 +29,7 @@ return (new PhpCsFixer\Config())
         ],
         'dir_constant' => true,
         'ereg_to_preg' => true,
-        'function_typehint_space' => true,
+        'type_declaration_spaces' => true,
         'include' => true,
         'increment_style' => [
             'style' => 'post',
@@ -54,7 +54,7 @@ return (new PhpCsFixer\Config())
         ],
         'no_null_property_initialization' => true,
         'no_superfluous_elseif' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,


### PR DESCRIPTION
The 2.x versions of the WP Coding Standards are often producing the following errors when you run `phpcs`, which pollutes the output: 

```php
FILE: stellarwp-web-common/Plugin.php
------------------------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 1 LINE
------------------------------------------------------------------------------------------------
 1 | ERROR | Missing file doc comment (Squiz.Commenting.FileComment.Missing)
 1 | ERROR | An error occurred during processing; checking has been aborted. The error message
   |       | was: trim(): Passing null to parameter #1 ($string) of type string is deprecated
   |       | in
   |       | /Users/stellarwp/Sites/orderable-website/wp-content/mu-plugins/stellarwp-web-common/stellarwp-web-common/vendor/wp-coding-standards/wpcs/WordPress/Sniffs/WP/I18nSniff.php
   |       | on line 194 (Internal.Exception)
------------------------------------------------------------------------------------------------
```

The line of code in `I18nSniff.php` that they mention is this:

```php
// Allow overruling the text_domain set in a ruleset via the command line.
$cl_text_domain = trim( PHPCSHelper::get_config_data( 'text_domain' ) );
``` 

I was hoping there was a way we could fix this by reconfiguring how we were setting our text domain in our PHPCS XML config files, but [the format we are using is correct](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#wordpresswpi18n-setting-your-text-domain):

```xml
<rule ref="WordPress.WP.I18n">
    <properties>
        <property name="text_domain" type="array">
            <element value="stellarwp-web-common"/>
        </property>
    </properties>
</rule>
```

Using a more up-to-date version of WPCS resolves this issue.